### PR TITLE
Don't tie release commits to ponylang-main account

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ jobs:
         uses: ponylang/release-bot-action@0.1.0
         with:
           step: start-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
@@ -86,6 +88,8 @@ jobs:
         uses: ponylang/release-bot-action@0.1.0
         with:
           step: trigger-release-announcement
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
@@ -119,6 +123,8 @@ jobs:
         uses: ponylang/release-bot-action@0.1.0
         with:
           step: announce-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           ASSET_NAME: "My awesome application/library"
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -7,3 +7,9 @@ inputs:
   step:
     description: 'start-a-release, trigger-release-announcement, or announce-a-release'
     required: true
+  git_user_name:
+    description: 'Name to associate with commits'
+    required: true
+  git_user_email:
+    description: 'Email to associate with commits'
+    required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ set -o errexit
 
 # Set up GitHub credentials
 # These are shared across all step types
-git config --global user.name 'Ponylang Main Bot'
-git config --global user.email 'ponylang.main@gmail.com'
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple
 
 # Determine step and run the corresponding script


### PR DESCRIPTION
This change, while a breaking change, will allow for the usage in
non-ponylang projects.

Closes #1