### PR TITLE
Make .release-notes support optional

### DIFF
--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -181,10 +181,12 @@ git checkout master
 git pull
 
 # rotate next-release.md content
-echo -e "\e[34mRotating release notes\e[0m"
-mv ".release-notes/next-release.md" ".release-notes/${VERSION}.md"
-touch ".release-notes/next-release.md"
-git add .release-notes/*
-git commit -m "Rotate release notes as part of ${VERSION} release [skip ci]"
-echo -e "\e[34mPushing release notes changes\e[0m"
-git push "${PUSH_TO}" master
+if test -f ".release-notes/next-release.md"; then
+  echo -e "\e[34mRotating release notes\e[0m"
+  mv ".release-notes/next-release.md" ".release-notes/${VERSION}.md"
+  touch ".release-notes/next-release.md"
+  git add .release-notes/*
+  git commit -m "Rotate release notes as part of ${VERSION} release [skip ci]"
+  echo -e "\e[34mPushing release notes changes\e[0m"
+  git push "${PUSH_TO}" master
+fi


### PR DESCRIPTION
When I added support for adding release notes from the release-notes-bot,
it was intended to be optional. However, because the rotation of the
new-release.md file wasn't wrapped in a check to see if it exists,
then using 0.2.1 without .release-notes/new-release.md would error out.

After this commit, release-notes-bot support is now actually optional.