### PR TITLE
Remove empty line in Last Week in Pony announcement

### DIFF
--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -133,7 +133,6 @@ lwip_url=$(echo "${result}" | jq -r '.[].url')
 if [ "$lwip_url" != "" ]; then
   body="
 Version ${VERSION} of ${GITHUB_REPOSITORY} has been released.
-
 See the [release notes](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}) for more details.
 "
 


### PR DESCRIPTION
The empty line is always removed manually, and it would be slightly convenient not to have to do that.