### PR TITLE
Remove unneeded [skip ci] in generated commits

### DIFF
--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -179,7 +179,7 @@ if test -f ".release-notes/next-release.md"; then
   mv ".release-notes/next-release.md" ".release-notes/${VERSION}.md"
   touch ".release-notes/next-release.md"
   git add .release-notes/*
-  git commit -m "Rotate release notes as part of ${VERSION} release [skip ci]"
+  git commit -m "Rotate release notes as part of ${VERSION} release"
   echo -e "\e[34mPushing release notes changes\e[0m"
   git push "${PUSH_TO}" master
 fi

--- a/scripts/start-a-release.bash
+++ b/scripts/start-a-release.bash
@@ -103,7 +103,7 @@ changelog-tool unreleased -e
 # commit changelog and push to master
 echo -e "\e[34mCommiting CHANGELOG.md change\e[0m"
 git add CHANGELOG.md
-git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release [skip ci]"
+git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release"
 
 echo -e "\e[34mPushing CHANGELOG.md\e[0m"
 git push "${PUSH_TO}" master


### PR DESCRIPTION
They are ignored by most of the services we now use.