### PR TITLE
Allow for overriding how trigger release announcement step gets version information

### DIFF
--- a/.github/workflows/release-notes-reminder.yml
+++ b/.github/workflows/release-notes-reminder.yml
@@ -1,7 +1,7 @@
 name: Release Notes Reminder
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:

--- a/.release-notes/23.md
+++ b/.release-notes/23.md
@@ -1,0 +1,36 @@
+## Allow for overriding how trigger release announcement step gets version information
+
+Adds an optional environment variable VERSION that can be set to an explicit value when using the trigger-release-announcement step instead of getting the version from GITHUB_REF.
+
+The VERSION environment variable allows for a wider variety of ways to trigger the step. Prior to this change, the step would not work if it wasn't triggered by pushing a tag. With this change, you can now use it other workflows.
+
+[ponyc](https://github.com/ponylang/ponyc) will use it to be triggered once assets are uploaded to Cloudsmith doing something slightly more complicated than the following simplified example:
+
+
+```yaml
+name: Handle external events
+
+on: repository_dispatch
+
+jobs:
+  trigger-release-announcement:
+    if: |
+      github.event.action == 'cloudsmith-package-synchronised' &&
+      github.event.client_payload.data.repository == 'releases' &&
+      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-musl.tar.gz'
+
+    name: Trigger release announcement
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Trigger
+        uses: ponylang/release-bot-action@0.3.2
+        with:
+          step: trigger-release-announcement
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ github.event.client_payload.data.version }}
+```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ jobs:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
 
+trigger-release-announcement, by default, will extract the version being released from the GITHUB_REF environment variable. For this default action to work, trigger-release-announcement must be kicked off by a tag being pushed. If you set up the step to be triggered in any other fashion it will not work unless you supply the version yourself. You can supply the version by providing an optional environment variable `VERSION` set to the version being released.
+
 ## announce-a-release
 
 Announces a release after artifacts have been built:

--- a/scripts/trigger-release-announcement.bash
+++ b/scripts/trigger-release-announcement.bash
@@ -48,10 +48,22 @@ set -o nounset
 
 PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-# Extract version from tag reference
-# Tag ref version: "refs/tags/1.0.0"
-# Version: "1.0.0"
-VERSION="${GITHUB_REF/refs\/tags\//}"
+if [[ -z "${VERSION}" ]]; then
+  echo -e "\e[34mOptional VERSION environment variable found. Using it.\e[0m"
+else
+  # Extract version from tag reference
+  # Tag ref version: "refs/tags/1.0.0"
+  # Version: "1.0.0"
+  # Note, this will only work if the action was kicked off by the push of tag.
+  # Anything else will result in the ref being something like
+  # "refs/heads/master" and the pushed tag will be something 'incorrect' like
+  # "announce-refs/heads/master".
+  # If you are using this action and it isn't triggered by a tag push, you must
+  # use the optional VERSION environment variable instead of falling back to
+  # the default behavior of extracting the version from GITHUB_REF.
+  echo -e "\e[34mExtracting version from GITHUB_REF.\e[0m"
+  VERSION="${GITHUB_REF/refs\/tags\//}"
+fi
 
 # tag for announcement
 echo -e "\e[34mTagging to kick off release announcement\e[0m"


### PR DESCRIPTION
Prior to this commit, the trigger release announcement step
gets the version from GITHUB_REF. For this to work, the step
has to be triggered by a tag being pushed.

This is good for most use-cases, but not all. For example, ponyc
build assets for release on cirrus-ci not github actions. This
means that we want to trigger a release announcement once we've
been notified assets have been uploaded to cloudsmith.

This will not work with trigger release announcement as it can't
get the version from GITHUB_REF as it isn't available there.

This commit adds the ability to provide an optional environment
variable VERSION to the trigger-release-announcement step. If the
variable is set, the version will be taken from that rather than
trying to parse it out of GITHUB_REF.

Closes #22