### PR TITLE
Allow for setting the default branch

### DIFF
--- a/.release-notes/24.md
+++ b/.release-notes/24.md
@@ -1,0 +1,9 @@
+## Allow for setting the default branch
+
+GitHub is in the process of changing the default branch for all newly created repositories from `master` to `main`. When that happens, this action will stop working for any new repos as it has `master` hardcoded as the default branch.
+
+With this change, release-bot-action now takes an optional input parameter `default_branch` that can be used to change what the default branch of the repo is.
+
+The default branch is the branch that we push back changelog, release note, and other changes. The default is set to `main` to be forward compatible with what will become standard on GitHub. Because `main` was chosen as the default, **this is a breaking change**.
+
+**All repositories still using `master` as the default branch will need to set the `default_branch` value to `master` to continue working** when they upgrade to a version of release-bot-action containing this commit.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ announce-a-release will post:
 
 Once announce-a-release has completed, the release process is done. For more in-depth details, please see each of the respective scripts in [scripts](scripts/).
 
-**N.B.** The environment variable `RELEASE_TOKEN` that is required by each step **must** be a personal access token with `public_repo` access. You can not use the `GITHUB_TOKEN` environment variable provided by GitHub's action environment. If you try to use `GITHUB_TOKEN`, no additional steps will trigger after start-a-release has completed.
-
 ## Example workflows
 
 ### start-a-release
@@ -124,4 +122,27 @@ jobs:
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           ZULIP_TOKEN: ${{ secrets.ZULIP_TOKEN }}
+```
+
+**N.B.** The environment variable `RELEASE_TOKEN` that is required by each step **must** be a personal access token with `public_repo` access. You can not use the `GITHUB_TOKEN` environment variable provided by GitHub's action environment. If you try to use `GITHUB_TOKEN`, no additional steps will trigger after start-a-release has completed.
+
+**N.B.** This action assumes that the default branch of your repository is named `main`. If it isn't named main, you will need to override that with an optional input parameter `default_branch`.
+
+For example, if your repository's default branch is called `trunk`, instead of having something like:
+
+```yml
+        with:
+          step: announce-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+```
+
+you would update to:
+
+```yml
+        with:
+          step: announce-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+          default_branch: "trunk"
 ```

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -17,7 +17,7 @@ cd release-bot-action-release-clean
 
 Before getting started, you will need a number for the version that you will be releasing as well as an agreed upon "golden commit" that will form the basis of the release.
 
-The "golden commit" must be `HEAD` on the `master` branch of this repository. At this time, releasing from any other location is not supported.
+The "golden commit" must be `HEAD` on the default branch (currently `master`) of this repository. At this time, releasing from any other location is not supported.
 
 For the duration of this document, that we are releasing version is `0.3.1`. Any place you see those values, please substitute your own version.
 

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,12 @@ inputs:
     description: 'start-a-release, trigger-release-announcement, or announce-a-release'
     required: true
   git_user_name:
-    description: 'Name to associate with commits'
+    description: 'Name to associate with commits.'
     required: true
   git_user_email:
-    description: 'Email to associate with commits'
+    description: 'Email to associate with commits.'
     required: true
+  default_branch:
+    description: 'Main branch for your repo.'
+    required: false
+    default: 'main'

--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -74,7 +74,7 @@ if test -f ".release-notes/next-release.md"; then
   echo -e "\e[34mnext-release.md found. Adding entries to release notes.\e[0m"
   fc=$(<".release-notes/next-release.md")
   release_notes="${fc}
-  
+
 "
 else
   echo -e "\e[34mNo next-release.md found. Only using changelog entries\e[0m"
@@ -169,10 +169,9 @@ fi
 echo -e "\e[34mDeleting no longer needed remote tag announce-${VERSION}\e[0m"
 git push --delete "${PUSH_TO}" "announce-${VERSION}"
 
-### this doesn't account for master changing commit, assumes we are HEAD
-# or can otherwise push without issue. that should error out without issue.
-# leaving us to restart from a different HEAD commit
-git checkout master
+# This doesn't account for the default branch changing commit. It assumes we
+# are HEAD or can otherwise push without issue.
+git checkout "${INPUT_DEFAULT_BRANCH}"
 git pull
 
 # rotate next-release.md content
@@ -183,5 +182,5 @@ if test -f ".release-notes/next-release.md"; then
   git add .release-notes/*
   git commit -m "Rotate release notes as part of ${VERSION} release"
   echo -e "\e[34mPushing release notes changes\e[0m"
-  git push "${PUSH_TO}" master
+  git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
 fi

--- a/scripts/start-a-release.bash
+++ b/scripts/start-a-release.bash
@@ -2,14 +2,14 @@
 
 # Starts the release process by:
 #
-# - Getting latest changes on master
+# - Getting latest changes on the default branch
 # - Updating version in
 #   - VERSION
 #   - CHANGELOG.md
-# - Pushing updated VERSION and CHANGELOG.md back to master
+# - Pushing updated VERSION and CHANGELOG.md back to the default branch
 # - Pushing tag to kick off building artifacts
 # - Adding a new "unreleased" section to CHANGELOG
-# - Pushing updated CHANGELOG back to master
+# - Pushing updated CHANGELOG back to the default branch
 #
 # Tools required in the environment that runs this:
 #
@@ -64,10 +64,9 @@ PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 # Version: "1.0.0"
 VERSION="${GITHUB_REF/refs\/tags\/release-/}"
 
-### this doesn't account for master changing commit, assumes we are HEAD
-# or can otherwise push without issue. that shouldl error out without issue.
-# leaving us to restart from a different HEAD commit
-git checkout master
+# this doesn't account for the default changing commit. It ssumes we are HEAD
+# or can otherwise push without issue.
+git checkout "${INPUT_DEFAULT_BRANCH}"
 git pull
 
 # update VERSION
@@ -88,8 +87,8 @@ echo -e "\e[34mTagging for release to kick off building artifacts\e[0m"
 git tag "${VERSION}"
 
 # push to release to remote
-echo -e "\e[34mPushing commited changes back to master\e[0m"
-git push "${PUSH_TO}" master
+echo -e "\e[34mPushing commited changes back to ${INPUT_DEFAULT_BRANCH}\e[0m"
+git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
 echo -e "\e[34mPushing ${VERSION} tag\e[0m"
 git push "${PUSH_TO}" "${VERSION}"
 
@@ -100,13 +99,13 @@ git pull
 echo -e "\e[34mAdding new 'unreleased' section to CHANGELOG.md\e[0m"
 changelog-tool unreleased -e
 
-# commit changelog and push to master
+# commit changelog and push to ${INPUT_DEFAULT_BRANCH}
 echo -e "\e[34mCommiting CHANGELOG.md change\e[0m"
 git add CHANGELOG.md
 git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release"
 
 echo -e "\e[34mPushing CHANGELOG.md\e[0m"
-git push "${PUSH_TO}" master
+git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
 
 # delete release-VERSION tag
 echo -e "\e[34mDeleting no longer needed remote tag release-${VERSION}\e[0m"

--- a/scripts/trigger-release-announcement.bash
+++ b/scripts/trigger-release-announcement.bash
@@ -48,8 +48,8 @@ if [[ -z "${VERSION}" ]]; then
   # Version: "1.0.0"
   # Note, this will only work if the action was kicked off by the push of tag.
   # Anything else will result in the ref being something like
-  # "refs/heads/master" and the pushed tag will be something 'incorrect' like
-  # "announce-refs/heads/master".
+  # "refs/heads/main" and the pushed tag will be something 'incorrect' like
+  # "announce-refs/heads/main".
   # If you are using this action and it isn't triggered by a tag push, you must
   # use the optional VERSION environment variable instead of falling back to
   # the default behavior of extracting the version from GITHUB_REF.


### PR DESCRIPTION
GitHub is in the process of changing the default branch for all
newly created repositories from `master` to `main`. When that happens,
this action will stop working for any new repos unless this change is
made.

With this change, release-bot-action now takes an optional input parameter
`default_branch` that can be used to change what the default branch of the
repo is.

The default branch is the branch that we push back changelog, release note,
and other changes. The default is set to `main` to be forward compatible with
what will become standard on GitHub. Because `main` was chosen as the default,
this is a breaking change.

All repositories still using `master` as the default branch will need to set
the `default_branch` value to `master` to continue working when they upgrade
to a version of release-bot-action containing this commit.