### PR TITLE
Update version in corral.json on release

### DIFF
--- a/.release-notes/28.md
+++ b/.release-notes/28.md
@@ -1,0 +1,3 @@
+## Update version in corral.json on release
+
+Prior to this release, the verison field in corral.json wasn't being updated on release.


### PR DESCRIPTION
There's an info.version field in corral.json that should be updated
on release. This change picks up doing that.

Closes #27