### PR TITLE
Use annotated tags for releases

### DIFF
--- a/.release-notes/30.md
+++ b/.release-notes/30.md
@@ -1,0 +1,5 @@
+## Use annotated tags for releases
+
+The release-bot-action will now use annotated rather than lightweight git tags when tagging releases.
+
+To learn more about the differences in tag types, please see [the documentation](https://git-scm.com/book/en/v2/Git-Basics-Tagging).

--- a/scripts/start-a-release.bash
+++ b/scripts/start-a-release.bash
@@ -97,7 +97,7 @@ git commit -m "${VERSION} release"
 
 # tag release
 echo -e "\e[34mTagging for release to kick off building artifacts\e[0m"
-git tag "${VERSION}"
+git tag -a "${VERSION}" -m "Version ${VERSION}"
 
 # push to release to remote
 echo -e "\e[34mPushing commited changes back to ${INPUT_DEFAULT_BRANCH}\e[0m"


### PR DESCRIPTION
The X.Y.Z tag will live on. Use an annotated tag as they can be signed.

From the documentation:

Annotated tags, however, are stored as full objects in the Git database.
They’re checksummed; contain the tagger name, email, and date; have a
tagging message; and can be signed and verified with GNU Privacy Guard
(GPG). It’s generally recommended that you create annotated tags so you
can have all this information; but if you want a temporary tag or for
some reason don’t want to keep the other information, lightweight tags
are available too.