### PR TITLE
Replace "step" input parameter with overriding of entrypoint

### DIFF
--- a/.release-notes/33.md
+++ b/.release-notes/33.md
@@ -1,0 +1,33 @@
+## Replace "step" input parameter with overriding of entrypoint
+
+Previously, when configuring the release-bot, you would indicate which step should be run like:
+
+```yml
+        with:
+          step: start-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+```
+
+`step` as an input option has been removed and replaced by `entrypoint`. `entrypoint` is an existing option that GitHub actions supports for changing the script to run from within an action.
+
+Previously, the steps where:
+
+- start-a-release
+- trigger-release-announcement
+- announce-a-release
+
+Those steps have been replaced with the following corresponding entrypoints:
+
+- start-a-release.bash
+- trigger-release-announcement.bash
+- announce-a-release.bash
+
+The aforementioned configuration from above would now be:
+
+```yml
+        with:
+          entrypoint: start-a-release.bash
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,13 @@ FROM alpine:3.12
 COPY --from=changelog-tool /usr/local/bin/changelog-tool /usr/local/bin/changelog-tool
 
 COPY entrypoint.sh /entrypoint.sh
-COPY scripts/announce-a-release.bash /announce-a-release.bash
-COPY scripts/start-a-release.bash /start-a-release.bash
-COPY scripts/trigger-release-announcement.bash /trigger-release-announcement.bash
+COPY scripts/announce-a-release.bash /commands/announce-a-release.bash
+COPY scripts/start-a-release.bash /commands/start-a-release.bash
+COPY scripts/trigger-release-announcement.bash /commands/trigger-release-announcement.bash
+
+ENV PATH "/commands:$PATH"
+
+RUN chmod a+x /commands/*
 
 RUN apk add --update --no-cache \
   bash \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - name: Start
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
-          step: start-a-release
+          entrypoint: start-a-release.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
         env:
@@ -81,7 +81,7 @@ jobs:
       - name: Trigger
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
-          step: trigger-release-announcement
+          entrypoint: trigger-release-announcement.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
         env:
@@ -116,7 +116,7 @@ jobs:
       - name: Announce
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
-          step: announce-a-release
+          entrypoint: announce-a-release.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
         env:
@@ -132,7 +132,7 @@ For example, if your repository's default branch is called `trunk`, instead of h
 
 ```yml
         with:
-          step: announce-a-release
+          entrypoint: announce-a-release.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
 ```
@@ -141,7 +141,7 @@ you would update to:
 
 ```yml
         with:
-          step: announce-a-release
+          entrypoint: announce-a-release.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
           default_branch: "trunk"

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
 inputs:
-  step:
-    description: 'start-a-release, trigger-release-announcement, or announce-a-release'
-    required: true
   git_user_name:
     description: 'Name to associate with commits.'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,27 +2,9 @@
 
 set -o errexit
 
-# Set up GitHub credentials
-# These are shared across all step types
-git config --global user.name "${INPUT_GIT_USER_NAME}"
-git config --global user.email "${INPUT_GIT_USER_EMAIL}"
-git config --global push.default simple
+echo -e "\e[31m'entrypoint' must be set; it should be one of: "
+echo -e "* /start-a-release.bash"
+echo -e "* /trigger-release-announcement.bash"
+echo -e "* /announce-a-release.bash\e[0m"
+exit 1;
 
-# Determine step and run the corresponding script
-case ${INPUT_STEP} in
-  start-a-release)
-    bash /start-a-release.bash
-    ;;
-  trigger-release-announcement)
-    bash /trigger-release-announcement.bash
-    ;;
-  announce-a-release)
-    bash /announce-a-release.bash
-    ;;
-  *)
-    echo -e "\e[31mUnknown step. 'step' should be one of: "
-    echo -e "* start-a-release"
-    echo -e "* trigger-release-announcement"
-    echo -e "* announce-a-release\e[0m"
-    exit 1;
-esac

--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -16,6 +16,10 @@
 
 set -o errexit
 
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
+git config --global push.default simple
+
 # Verify ENV is set up correctly
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should

--- a/scripts/start-a-release.bash
+++ b/scripts/start-a-release.bash
@@ -21,6 +21,10 @@
 
 set -o errexit
 
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
+git config --global push.default simple
+
 # Verify ENV is set up correctly
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should

--- a/scripts/trigger-release-announcement.bash
+++ b/scripts/trigger-release-announcement.bash
@@ -16,6 +16,10 @@
 
 set -o errexit
 
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
+git config --global push.default simple
+
 # Verify ENV is set up correctly
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should


### PR DESCRIPTION
GitHub actions already provides a mean to run a specific "subcommand"
via changing the entrypoint. Having a "step" input that operated in the
same way but different from what GitHub actions had built in feels problematic.

This change is a first step towards a rather large redoing of the release-bot-action.