### PR TITLE
Switch supported actions/checkout from v1 to v2

### DIFF
--- a/.release-notes/34.md
+++ b/.release-notes/34.md
@@ -1,0 +1,12 @@
+## Switch supported actions/checkout from v1 to v2
+
+We've switched from supporting `actions/checkout@v1` to `actions/checkout@v2`.
+
+The are a few changes to configuration of release-bot that come along with this change. You should check out the examples in the README.md to see the latest on how to configure.
+
+Highlights of changes:
+
+- Use `actions/checkout@v2`
+- `action/checkout` requires the setting `token` and `ref` values.
+- Most workflows no longer require a release token being passed to the action, only to `actions/checkout`.
+- Workflows no longer take a default branch. The default branch is now handled by `actions/checkout@v2`.

--- a/README.md
+++ b/README.md
@@ -42,15 +42,16 @@ jobs:
     name: Start a release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Start
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
           entrypoint: start-a-release.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
 
 ## trigger-release-announcement
@@ -78,14 +79,15 @@ jobs:
     needs: [ARTIFACT_BUILDING_STEPS_HERE]
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
           entrypoint: trigger-release-announcement.bash
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
 
 trigger-release-announcement, by default, will extract the version being released from the GITHUB_REF environment variable. For this default action to work, trigger-release-announcement must be kicked off by a tag being pushed. If you set up the step to be triggered in any other fashion it will not work unless you supply the version yourself. You can supply the version by providing an optional environment variable `VERSION` set to the version being released.
@@ -113,6 +115,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Announce
         uses: docker://ponylang/release-bot-action:0.5.0
         with:
@@ -126,23 +131,4 @@ jobs:
 
 **N.B.** The environment variable `RELEASE_TOKEN` that is required by each step **must** be a personal access token with `public_repo` access. You can not use the `GITHUB_TOKEN` environment variable provided by GitHub's action environment. If you try to use `GITHUB_TOKEN`, no additional steps will trigger after start-a-release has completed.
 
-**N.B.** This action assumes that the default branch of your repository is named `main`. If it isn't named main, you will need to override that with an optional input parameter `default_branch`.
-
-For example, if your repository's default branch is called `trunk`, instead of having something like:
-
-```yml
-        with:
-          entrypoint: announce-a-release.bash
-          git_user_name: "Ponylang Main Bot"
-          git_user_email: "ponylang.main@gmail.com"
-```
-
-you would update to:
-
-```yml
-        with:
-          entrypoint: announce-a-release.bash
-          git_user_name: "Ponylang Main Bot"
-          git_user_email: "ponylang.main@gmail.com"
-          default_branch: "trunk"
-```
+**N.B.** you should set the `ref` input value to `actions/checkout@v2` to whatever the default branch of your repository is. The examples above assume that your default branch name is `main`.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,3 @@ inputs:
   git_user_email:
     description: 'Email to associate with commits.'
     required: true
-  default_branch:
-    description: 'Main branch for your repo.'
-    required: false
-    default: 'main'

--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -41,19 +41,6 @@ if [[ -z "${GITHUB_REPOSITORY}" ]]; then
   exit 1
 fi
 
-if [[ -z "${RELEASE_TOKEN}" ]]; then
-  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
-  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
-  echo -e "\e[31mpersonal access token otherwise next steps in the release"
-  echo -e "\e[31mprocess WILL NOT trigger."
-  echo -e "\e[31mPersonal access tokens are in the form:"
-  echo -e "\e[31m     TOKEN"
-  echo -e "\e[31mfor example:"
-  echo -e "\e[31m     1234567890"
-  echo -e "\e[31mExiting.\e[0m"
-  exit 1
-fi
-
 if [[ -z "${ZULIP_TOKEN}" ]]; then
   echo -e "\e[31mA Zulip access token needs to be set in ZULIP_TOKEN."
   echo -e "Exiting.\e[0m"
@@ -63,8 +50,6 @@ fi
 # no unset variables allowed from here on out
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
-
-PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 # Extract version from tag reference
 # Tag ref version: "refs/tags/announce-1.0.0"
@@ -171,11 +156,10 @@ fi
 
 # delete announce-VERSION tag
 echo -e "\e[34mDeleting no longer needed remote tag announce-${VERSION}\e[0m"
-git push --delete "${PUSH_TO}" "announce-${VERSION}"
+git push --delete origin "announce-${VERSION}"
 
 # This doesn't account for the default branch changing commit. It assumes we
 # are HEAD or can otherwise push without issue.
-git checkout "${INPUT_DEFAULT_BRANCH}"
 git pull
 
 # rotate next-release.md content
@@ -186,5 +170,5 @@ if test -f ".release-notes/next-release.md"; then
   git add .release-notes/*
   git commit -m "Rotate release notes as part of ${VERSION} release"
   echo -e "\e[34mPushing release notes changes\e[0m"
-  git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
+  git push
 fi

--- a/scripts/start-a-release.bash
+++ b/scripts/start-a-release.bash
@@ -38,32 +38,9 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
-if [[ -z "${GITHUB_REPOSITORY}" ]]; then
-  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
-  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
-  echo -e "\e[31m     ponylang/ponyup"
-  echo -e "\e[31mExiting.\e[0m"
-  exit 1
-fi
-
-if [[ -z "${RELEASE_TOKEN}" ]]; then
-  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
-  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
-  echo -e "\e[31mpersonal access token otherwise next steps in the release"
-  echo -e "\e[31mprocess WILL NOT trigger."
-  echo -e "\e[31mPersonal access tokens are in the form:"
-  echo -e "\e[31m     TOKEN"
-  echo -e "\e[31mfor example:"
-  echo -e "\e[31m     1234567890"
-  echo -e "\e[31mExiting.\e[0m"
-  exit 1
-fi
-
 # no unset variables allowed from here on out
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
-
-PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 # Extract version from tag reference
 # Tag ref version: "refs/tags/release-1.0.0"
@@ -72,7 +49,6 @@ VERSION="${GITHUB_REF/refs\/tags\/release-/}"
 
 # this doesn't account for the default changing commit. It ssumes we are HEAD
 # or can otherwise push without issue.
-git checkout "${INPUT_DEFAULT_BRANCH}"
 git pull
 
 # update VERSION
@@ -104,10 +80,10 @@ echo -e "\e[34mTagging for release to kick off building artifacts\e[0m"
 git tag -a "${VERSION}" -m "Version ${VERSION}"
 
 # push to release to remote
-echo -e "\e[34mPushing commited changes back to ${INPUT_DEFAULT_BRANCH}\e[0m"
-git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
+echo -e "\e[34mPushing commited changes\e[0m"
+git push
 echo -e "\e[34mPushing ${VERSION} tag\e[0m"
-git push "${PUSH_TO}" "${VERSION}"
+git push origin "${VERSION}"
 
 # pull again, just in case, odds of this being needed are really slim
 git pull
@@ -116,14 +92,14 @@ git pull
 echo -e "\e[34mAdding new 'unreleased' section to CHANGELOG.md\e[0m"
 changelog-tool unreleased -e
 
-# commit changelog and push to ${INPUT_DEFAULT_BRANCH}
+# commit changelog and push
 echo -e "\e[34mCommiting CHANGELOG.md change\e[0m"
 git add CHANGELOG.md
 git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release"
 
 echo -e "\e[34mPushing CHANGELOG.md\e[0m"
-git push "${PUSH_TO}" "${INPUT_DEFAULT_BRANCH}"
+git push
 
 # delete release-VERSION tag
 echo -e "\e[34mDeleting no longer needed remote tag release-${VERSION}\e[0m"
-git push --delete "${PUSH_TO}" "release-${VERSION}"
+git push --delete origin "release-${VERSION}"

--- a/scripts/trigger-release-announcement.bash
+++ b/scripts/trigger-release-announcement.bash
@@ -33,19 +33,6 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
-if [[ -z "${RELEASE_TOKEN}" ]]; then
-  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
-  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
-  echo -e "\e[31mpersonal access token otherwise next steps in the release"
-  echo -e "\e[31mprocess WILL NOT trigger."
-  echo -e "\e[31mPersonal access tokens are in the form:"
-  echo -e "\e[31m     TOKEN"
-  echo -e "\e[31mfor example:"
-  echo -e "\e[31m     1234567890"
-  echo -e "\e[31mExiting.\e[0m"
-  exit 1
-fi
-
 if [[ -z "${VERSION}" ]]; then
   # Extract version from tag reference
   # Tag ref version: "refs/tags/1.0.0"
@@ -67,12 +54,10 @@ fi
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
 
-PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
 # tag for announcement
 echo -e "\e[34mTagging to kick off release announcement\e[0m"
 git tag "announce-${VERSION}"
 
 # push tag
 echo -e "\e[34mPushing announce-${VERSION} tag\e[0m"
-git push "${PUSH_TO}" "announce-${VERSION}"
+git push origin "announce-${VERSION}"


### PR DESCRIPTION
When we were supporting v1, we had to take a default branch to push
changes back to as well as jump through hoops with setting up proper
access urls to push to it.

actions/checkout v2 is a lot more featureful. One of those features
is to take a branch (under the input `ref`) to check out as well as
the token to use to checkout.

Switching to v2 and moving the "default branch" and "token to push/pull
GitHub with" into the checkout step from our scripts is an overall win.

This is a breaking change as I don't want to try to figure out supporting
both v1 and v2.

Closes #32