### PR TITLE
Add command to update the runner in action.yml files

### DIFF
--- a/.release-notes/38.md
+++ b/.release-notes/38.md
@@ -1,0 +1,28 @@
+## Add command to update the runner in action.yml files
+
+The best way to run a released GitHub action is to use a prebuilt docker
+image. This saves time with building the image and guarantees that each
+run will be using exactly the same action code.
+
+This is best accomplished by settings runs.image to the image in question
+in action.yml.
+
+However, this does have a drawback of not being able to use arbitrary commits
+to run with as that commit will be grabbed BUT... the image in its action.yml
+will be used. This is problematic for testing actions.
+
+The two commands included in this commit address both issues.
+
+### update-action-to-use-docker-image-to-run-action.py
+
+Updates runs.image to a docker image with the version we are releasing.
+As part of the release process for an action, it should then also make
+sure to push a prebuilt image to DockerHub for the action in question.
+
+This command should be run in the pre-tagging job.
+
+### update-action-to-use-dockerfile-to-run-action.py
+
+Switches back to using `Dockerfile` for how to run the action.
+
+This command should be run in the post-tagging job.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN apk add --update --no-cache \
   grep \
   py3-pip
 
-
 RUN pip3 install \
   gitpython \
-  pylint
+  pylint \
+  pyyaml
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ else
   IMAGE_TAG := $(tag)
 endif
 
+PYTHON_COMMANDS := $(shell find $(SRC_DIR) -name *.py)
+
 all: build
 
 build:
@@ -16,7 +18,10 @@ push: build
 	docker push "${IMAGE}:${IMAGE_TAG}"
 	docker push "${IMAGE}:latest"
 
-pylint: build
-	docker run --entrypoint pylint --rm "${IMAGE}:latest" /commands/update-version-in-README.py
+pylint: build $(PYTHON_COMMANDS)
+	$(foreach file, $(notdir $(PYTHON_COMMANDS)), \
+		echo "Linting $(file)"; \
+		docker run --entrypoint pylint --rm "${IMAGE}:latest" /commands/$(file); \
+	)
 
 .PHONY: build push pylint

--- a/scripts/update-action-to-use-docker-image-to-run-action.py
+++ b/scripts/update-action-to-use-docker-image-to-run-action.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
+
+import os
+import os.path
+import re
+import sys
+import git
+from git.exc import GitCommandError
+import yaml
+
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
+NOTICE = '\033[33m'
+
+# validate action.yml exists
+if not os.path.isfile("action.yml"):
+    print(ERROR + "Unable to find action.yml. Exiting." + ENDC)
+    sys.exit(1)
+
+# Get repository and version names from the environment
+# version is in the form of "refs/tags/release-1.0.0" where the version is 1.0.0
+repository = os.environ['GITHUB_REPOSITORY']
+version = re.sub('refs/tags/release-', '', os.environ['GITHUB_REF'])
+
+git = git.Repo(os.environ['GITHUB_WORKSPACE']).git
+print(INFO + "Setting up git configuration." + ENDC)
+git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
+git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
+git.config('--global', 'branch.autosetuprebase', 'always')
+
+# open README and update with new version
+print(INFO + "Switching to prebuilt image as runner in action.yml" + ENDC)
+with open("action.yml", "r+") as action_yml:
+    text = yaml.safe_load(action_yml)
+    text['runs']['image'] = f'docker://{repository}:{version}'
+    action_yml.seek(0)
+    yaml.dump(text, action_yml)
+    action_yml.truncate()
+
+print(INFO + "Adding git changes." + ENDC)
+git.add("action.yml")
+if not git.status("-s"):
+    print(INFO + "No changes. Exiting." + ENDC)
+    sys.exit(0)
+git.commit('-m',
+    f'Update action.yml to run with prebuilt docker image for new version {version}')
+
+push_failures = 0
+while True:
+    try:
+        print(INFO + "Pushing updated action.yml." + ENDC)
+        git.push()
+        break
+    except GitCommandError:
+        push_failures += 1
+        if push_failures <= 5:
+            print(NOTICE
+                  + "Failed to push. Going to pull and try again."
+                  + ENDC)
+            git.pull(rebase=True)
+        else:
+            print(ERROR + "Failed to push again. Giving up." + ENDC)
+            raise

--- a/scripts/update-action-to-use-dockerfile-to-run-action.py
+++ b/scripts/update-action-to-use-dockerfile-to-run-action.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
+
+import os
+import os.path
+import sys
+import git
+from git.exc import GitCommandError
+import yaml
+
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
+NOTICE = '\033[33m'
+
+# validate action.yml exists
+if not os.path.isfile("action.yml"):
+    print(ERROR + "Unable to find action.yml. Exiting." + ENDC)
+    sys.exit(1)
+
+# Get repository from the environment
+repository = os.environ['GITHUB_REPOSITORY']
+
+git = git.Repo(os.environ['GITHUB_WORKSPACE']).git
+print(INFO + "Setting up git configuration." + ENDC)
+git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
+git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
+git.config('--global', 'branch.autosetuprebase', 'always')
+
+# open README and update with new version
+print(INFO + "Switching to Dockerfile as runner in action.yml" + ENDC)
+with open("action.yml", "r+") as action_yml:
+    text = yaml.safe_load(action_yml)
+    text['runs']['image'] = 'Dockerfile'
+    action_yml.seek(0)
+    yaml.dump(text, action_yml)
+    action_yml.truncate()
+
+print(INFO + "Adding git changes." + ENDC)
+git.add("action.yml")
+if not git.status("-s"):
+    print(INFO + "No changes. Exiting." + ENDC)
+    sys.exit(0)
+git.commit('-m',
+    'Update action.yml to run with Dockerfile')
+
+push_failures = 0
+while True:
+    try:
+        print(INFO + "Pushing updated action.yml." + ENDC)
+        git.push()
+        break
+    except GitCommandError:
+        push_failures += 1
+        if push_failures <= 5:
+            print(NOTICE
+                  + "Failed to push. Going to pull and try again."
+                  + ENDC)
+            git.pull(rebase=True)
+        else:
+            print(ERROR + "Failed to push again. Giving up." + ENDC)
+            raise


### PR DESCRIPTION
The best way to run a released GitHub action is to use a prebuilt docker
image. This saves time with building the image and guarantees that each
run will be using exactly the same action code.

This is best accomplished by settings runs.image to the image in question
in action.yml.

However, this does have a drawback of not being able to use arbitrary commits
to run with as that commit will be grabbed BUT... the image in its action.yml
will be used. This is problematic for testing actions.

The two commands included in this commit address both issues.

- update-action-to-use-docker-image-to-run-action.py

Updates runs.image to a docker image with the version we are releasing.
As part of the release process for an action, it should then also make
sure to push a prebuilt image to DockerHub for the action in question.

This command should be run in the pre-tagging job.

- update-action-to-use-dockerfile-to-run-action.py

Switches back to using `Dockerfile` for how to run the action.

This command should be run in the post-tagging job.