### PR TITLE
Fix data corruption bug in new readme-version-updater command

### DIFF
--- a/scripts/update-version-in-README.py
+++ b/scripts/update-version-in-README.py
@@ -62,6 +62,7 @@ with open(readme_file, "r+") as readme:
         text = re.sub(find, replace, text)
     readme.seek(0)
     readme.write(text)
+    readme.truncate()
 
 print(INFO + "Adding git changes." + ENDC)
 git.add(readme_file)


### PR DESCRIPTION
If the new version was not as long as the old in terms of characters,
it would leave "extra" characters around as we weren't truncating the file
to our new length.