### PR TITLE
Add preartefact-changelog-check.bash command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,28 @@ on:
       - \d+.\d+.\d+
 
 jobs:
+  # validation to assure that we should in fact continue with the release should
+  # be done here. the primary reason for this step is to verify that the release
+  # was started correctly by pushing a `release-X.Y.Z` tag rather than `X.Y.Z`.
+  pre-artefact-creation:
+    name: Tasks to run before artefact creation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Validate CHANGELOG
+        uses: ponylang/release-bot-action@main
+        with:
+          entrypoint: pre-artefact-changelog-check.bash
+
   build-and-push-image:
     name: Build and push action image
     runs-on: ubuntu-latest
+    needs:
+      - pre-artefact-creation
     steps:
       - uses: actions/checkout@v2
       - name: Docker login
@@ -19,25 +38,11 @@ jobs:
       - name: Build and push
         run: make push
 
-  update-version-in-readme-examples:
-    name: Update version in README examples
-    runs-on: ubuntu-latest
-    needs:
-      - build-and-push-image
-    steps:
-      - name: Update version in README examples
-        uses: docker://ponylang/readme-version-updater-action:0.3.1
-        with:
-          git_user_name: "Ponylang Main Bot"
-          git_user_email: "ponylang.main@gmail.com"
-        env:
-          API_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
-
   trigger-release-announcement:
     name: Trigger release announcement
     runs-on: ubuntu-latest
     needs:
-      - update-version-in-readme-examples
+      - build-and-push-image
     steps:
       - uses: actions/checkout@v1
       - name: Trigger

--- a/.release-notes/26.md
+++ b/.release-notes/26.md
@@ -1,0 +1,5 @@
+## Add preartefact-changelog-check.bash command
+
+The preartefact-changelog-check.bash command validates that the changelog contains an entry for `X.Y.Z` where `X.Y.Z` is the release that is underway.
+
+The command can be used to protect against misconfiguration of workflows and more importantly, a user inadvertently pushing a `X.Y.Z` tag to start a release rather than the correct `release-X.Y.Z`.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,25 @@ on:
       - \d+.\d+.\d+
 
 jobs:
+  # validation to assure that we should in fact continue with the release should
+  # be done here. the primary reason for this step is to verify that the release
+  # was started correctly by pushing a `release-X.Y.Z` tag rather than `X.Y.Z`.
+  pre-artefact-creation:
+    name: Tasks to run before artefact creation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Validate CHANGELOG
+        uses: ponylang/release-bot-action@0.5.0
+        with:
+          entrypoint: pre-artefact-changelog-check.bash
+
   # Artefact building steps go here
+  # they should all depend on the `pre-artefact-creation` job finishing
 
   trigger-release-announcement:
     name: Trigger release announcement

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,3 @@ description: 'Standard Pony Library and Application release functionality'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-inputs:
-  git_user_name:
-    description: 'Name to associate with commits.'
-    required: true
-  git_user_email:
-    description: 'Email to associate with commits.'
-    required: true

--- a/scripts/add-unreleased-section-to-changelog.bash
+++ b/scripts/add-unreleased-section-to-changelog.bash
@@ -23,6 +23,24 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
 git config --global user.name "${INPUT_GIT_USER_NAME}"
 git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple

--- a/scripts/announce-a-release.bash
+++ b/scripts/announce-a-release.bash
@@ -16,10 +16,6 @@
 
 set -o errexit
 
-git config --global user.name "${INPUT_GIT_USER_NAME}"
-git config --global user.email "${INPUT_GIT_USER_EMAIL}"
-git config --global push.default simple
-
 # Verify ENV is set up correctly
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should
@@ -46,6 +42,28 @@ if [[ -z "${ZULIP_TOKEN}" ]]; then
   echo -e "Exiting.\e[0m"
   exit 1
 fi
+
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
+git config --global push.default simple
 
 # no unset variables allowed from here on out
 # allow above so we can display nice error messages for expected unset variables

--- a/scripts/pre-artefact-changelog-check.bash
+++ b/scripts/pre-artefact-changelog-check.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Validates that there is a CHANGELOG entry for the given tag.
+# The only reasons for it to be missing are:
+#
+# - misconfigured workflows
+# - user mistake in pushing `x.y.z` tag instead of `release-x.y.z`
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - changelog-tool
+
+set -o errexit
+
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the GitHub actions environment should
+# provide all of these if properly configured
+if [[ -z "${GITHUB_REF}" ]]; then
+  echo -e "\e[31mThe release tag needs to be set in GITHUB_REF."
+  echo -e "\e[31mThe tag should be in the following GitHub specific form:"
+  echo -e "\e[31m    /refs/tags/release-X.Y.Z"
+  echo -e "\e[31mwhere X.Y.Z is the version we are releasing"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+# Extract version from tag reference
+# Tag ref version: "refs/tags/release-1.0.0"
+# Version: "1.0.0"
+VERSION="${GITHUB_REF/refs\/tags\//}"
+
+# If we can get the tag from the changelog-tool then at it was correctly setup
+# for release
+
+changelog-tool get "${VERSION}"

--- a/scripts/trigger-artefact-creation.bash
+++ b/scripts/trigger-artefact-creation.bash
@@ -24,6 +24,24 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
 git config --global user.name "${INPUT_GIT_USER_NAME}"
 git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple

--- a/scripts/trigger-release-announcement.bash
+++ b/scripts/trigger-release-announcement.bash
@@ -16,10 +16,6 @@
 
 set -o errexit
 
-git config --global user.name "${INPUT_GIT_USER_NAME}"
-git config --global user.email "${INPUT_GIT_USER_EMAIL}"
-git config --global push.default simple
-
 # Verify ENV is set up correctly
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should
@@ -49,6 +45,28 @@ if [[ -z "${VERSION}" ]]; then
 else
   echo -e "\e[34mOptional VERSION environment variable found. Using it.\e[0m"
 fi
+
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+git config --global user.name "${INPUT_GIT_USER_NAME}"
+git config --global user.email "${INPUT_GIT_USER_EMAIL}"
+git config --global push.default simple
 
 # no unset variables allowed from here on out
 # allow above so we can display nice error messages for expected unset variables

--- a/scripts/update-action-to-use-docker-image-to-run-action.py
+++ b/scripts/update-action-to-use-docker-image-to-run-action.py
@@ -15,6 +15,21 @@ ERROR = '\033[31m'
 INFO = '\033[34m'
 NOTICE = '\033[33m'
 
+# validate env
+if 'INPUT_GIT_USER_NAME' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_NAME needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
+if 'INPUT_GIT_USER_EMAIL' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_EMAIL needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
 # validate action.yml exists
 if not os.path.isfile("action.yml"):
     print(ERROR + "Unable to find action.yml. Exiting." + ENDC)

--- a/scripts/update-action-to-use-dockerfile-to-run-action.py
+++ b/scripts/update-action-to-use-dockerfile-to-run-action.py
@@ -14,6 +14,21 @@ ERROR = '\033[31m'
 INFO = '\033[34m'
 NOTICE = '\033[33m'
 
+# validate env
+if 'INPUT_GIT_USER_NAME' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_NAME needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
+if 'INPUT_GIT_USER_EMAIL' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_EMAIL needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
 # validate action.yml exists
 if not os.path.isfile("action.yml"):
     print(ERROR + "Unable to find action.yml. Exiting." + ENDC)

--- a/scripts/update-changelog-for-release.bash
+++ b/scripts/update-changelog-for-release.bash
@@ -23,6 +23,24 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
 git config --global user.name "${INPUT_GIT_USER_NAME}"
 git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple

--- a/scripts/update-version-in-README.py
+++ b/scripts/update-version-in-README.py
@@ -14,6 +14,21 @@ ERROR = '\033[31m'
 INFO = '\033[34m'
 NOTICE = '\033[33m'
 
+# validate env
+if 'INPUT_GIT_USER_NAME' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_NAME needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
+if 'INPUT_GIT_USER_EMAIL' not in os.environ:
+    print(ERROR + "INPUT_GIT_USER_EMAIL needs to be set in env." + ENDC)
+    print(ERROR + "It can be set in a GitHub action by passing" + ENDC)
+    print(ERROR + "`git_user_name` to the step in a `with` block." + ENDC)
+    print(ERROR + "Exiting." + ENDC)
+    sys.exit(1)
+
 # Get repository and version names from the environment
 # version is in the form of "refs/tags/release-1.0.0" where the version is 1.0.0
 repository = os.environ['GITHUB_REPOSITORY']

--- a/scripts/update-version-in-VERSION.bash
+++ b/scripts/update-version-in-VERSION.bash
@@ -22,6 +22,24 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
 git config --global user.name "${INPUT_GIT_USER_NAME}"
 git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple

--- a/scripts/update-version-in-corral-json.bash
+++ b/scripts/update-version-in-corral-json.bash
@@ -23,6 +23,24 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
+if [[ -z "${INPUT_GIT_USER_NAME}" ]]; then
+  echo -e "\e[31mThe user name associated with git commits needs to be set in "
+  echo -e "\e[31mINPUT_GIT_USER_NAME."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_name'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${INPUT_GIT_USER_EMAIL}" ]]; then
+  echo -e "\e[31mThe email address associated with git commits needs to be set "
+  echo -e "\e[31min INPUT_GIT_USER_EMAIL."
+  echo -e "\e[31mIn a workflow, the would be set by creating a 'with' block "
+  echo -e "\e[32mand providing 'git_user_email'."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
 git config --global user.name "${INPUT_GIT_USER_NAME}"
 git config --global user.email "${INPUT_GIT_USER_EMAIL}"
 git config --global push.default simple


### PR DESCRIPTION
The preartefact-changelog-check.bash command validates that the changelog
contains an entry for `X.Y.Z` where `X.Y.Z` is the release that is underway.

The command can be used to protect against misconfiguration of workflows and
more importantly, a user inadvertently pushing a `X.Y.Z` tag to start a release
rather than the correct `release-X.Y.Z`.

Closes #26