### PR TITLE
Add support for ponyc's specialized build requirements

### DIFF
--- a/.release-notes/ponyc-special-release.md
+++ b/.release-notes/ponyc-special-release.md
@@ -1,0 +1,7 @@
+## Add support for ponyc's specialized build requirements
+
+We build ponyc in CirrusCI, not GitHub actions. We do this because we often need to build LLVM from source and GitHub doesn't provide execution environments that are powerful enough. This results in a change where we can't use a stock release-bot `trigger-release-announcement` command.
+
+When the ponyc workflow goes to trigger release announcements, the tag used to build isn't available so the version needs to be provided via the `CUSTOM_VERSION` environment variable that is added in this change.
+
+This functionality should have been included in 0.6.0 but was missed.

--- a/scripts/trigger-release-announcement
+++ b/scripts/trigger-release-announcement
@@ -36,8 +36,14 @@ if 'GITHUB_WORKSPACE' not in os.environ:
     print(ERROR + "GITHUB_WORKSPACE needs to be set in env. Exiting." + ENDC)
     sys.exit(1)
 
-# version is in the form of "refs/tags/release-1.0.0" where the version is 1.0.0
-version = re.sub('refs/tags/', '', os.environ['GITHUB_REF'])
+if 'CUSTOM_VERSION' not in os.environ:
+    # version is in the form of "refs/tags/release-1.0.0"
+    # where the version is 1.0.0
+    version = re.sub('refs/tags/', '', os.environ['GITHUB_REF'])
+else:
+    # some workflows like ponyc have to build outside of GitHub actions
+    # this allows the setting of a custom variable to trigger the next step
+    version = os.environ['CUSTOM_VERSION']
 
 git = git.Repo(os.environ['GITHUB_WORKSPACE']).git
 print(INFO + "Setting up git configuration." + ENDC)


### PR DESCRIPTION
We build ponyc in CirrusCI, not GitHub actions. We do this because we
often need to build LLVM from source and GitHub doesn't provide execution
environments that are powerful enough. This results in a change where we
can't use a stock release-bot `trigger-release-announcement` command.

When the ponyc workflow goes to trigger release announcements, the tag
used to build isn't available so the version needs to be provided via the
`CUSTOM_VERSION` environment variable that is added in this change.

This functionality should have been included in 0.6.0 but was missed.