### PR TITLE
Switch Dockerfile to be based on Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM ponylang/changelog-tool:release AS changelog-tool
-FROM alpine:3.12
+FROM ubuntu:20.04
 
-RUN apk add --update --no-cache \
-  git \
-  py3-pip
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     git \
+     python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -y autoremove --purge \
+  && apt-get -y clean
 
 RUN pip3 install \
   gitpython \
-  pygithub==1.54.1 \
+  pygithub \
   pylint \
   pyyaml \
   zulip


### PR DESCRIPTION
PyGitHub needs the python crypto library and there are no wheels for
that available on Alpine. To use the newer version of PyGitHub, we need
to build the crypto library from source and that now means setting up
rust.

The result... it takes much longer to build from an Alpine base.

Closes #49