### PR TITLE
Update to work with newer versions of git

### DIFF
--- a/.release-notes/cranky-git.md
+++ b/.release-notes/cranky-git.md
@@ -1,0 +1,5 @@
+## Update to work with newer versions of git
+
+Newer versions of git have added a check to see if the user running a command is the same as the user who owns the repository. If they don't match, the command fails. Adding the repository directory to a "safe list" addresses the issue.
+
+We've updated accordingly.

--- a/scripts/add-unreleased-section-to-changelog
+++ b/scripts/add-unreleased-section-to-changelog
@@ -46,6 +46,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 if not os.path.isfile("CHANGELOG.md"):
     print(ERROR + "Unable to find CHANGELOG.md. Exiting." + ENDC)

--- a/scripts/delete-announcement-tag
+++ b/scripts/delete-announcement-tag
@@ -44,6 +44,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 announcement_tag = f'announce-{version}'
 print(INFO + "Deleting no longer needed remote tag " + announcement_tag + ENDC)

--- a/scripts/rotate-release-notes
+++ b/scripts/rotate-release-notes
@@ -45,6 +45,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 if not os.path.isfile('.release-notes/next-release.md'):
     print(ERROR + "Unable to find release-notes/next-release.md. Exiting."

--- a/scripts/trigger-artefact-creation
+++ b/scripts/trigger-artefact-creation
@@ -44,6 +44,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 print(INFO + "Tagging for release to kick off creating artefacts" + ENDC)
 git.tag('-a', version, '-m', f'Version {version}')

--- a/scripts/trigger-release-announcement
+++ b/scripts/trigger-release-announcement
@@ -50,6 +50,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 announce_tag = f'announce-{version}'
 

--- a/scripts/update-action-to-use-docker-image-to-run-action
+++ b/scripts/update-action-to-use-docker-image-to-run-action
@@ -57,6 +57,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 # open README and update with new version
 print(INFO + "Switching to prebuilt image as runner in action.yml" + ENDC)

--- a/scripts/update-action-to-use-dockerfile-to-run-action
+++ b/scripts/update-action-to-use-dockerfile-to-run-action
@@ -47,6 +47,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 # open README and update with new version
 print(INFO + "Switching to Dockerfile as runner in action.yml" + ENDC)

--- a/scripts/update-changelog-for-release
+++ b/scripts/update-changelog-for-release
@@ -46,6 +46,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 if not os.path.isfile('CHANGELOG.md'):
     print(ERROR + "Unable to find CHANGELOG.md. Exiting." + ENDC)

--- a/scripts/update-version-in-README
+++ b/scripts/update-version-in-README
@@ -51,6 +51,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 # what to find and what to replace it with
 subs = [

--- a/scripts/update-version-in-VERSION
+++ b/scripts/update-version-in-VERSION
@@ -45,6 +45,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 if not os.path.isfile('VERSION'):
     print(ERROR + "Unable to find VERSION. Exiting." + ENDC)

--- a/scripts/update-version-in-corral-json
+++ b/scripts/update-version-in-corral-json
@@ -46,6 +46,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 if not os.path.isfile('corral.json'):
     print(ERROR + "Unable to find corral.json. Exiting." + ENDC)


### PR DESCRIPTION
Newer versions of git have added a check to see if the user running a command
is the same as the user who owns the repository. If they don't match, the
command fails. Adding the repository directory to a "safe list" addresses the
issue.