### PR TITLE
Fixed syntax error in `update-action-to-use-docker-image-to-run-action`

### DIFF
--- a/.release-notes/fix-broken.md
+++ b/.release-notes/fix-broken.md
@@ -1,0 +1,5 @@
+## Fixed syntax error in `update-action-to-use-docker-image-to-run-action`
+
+It turns out our CI linting would show green for code that had failed linting. That is a bad setup. In the process, the last release had a syntax error in it.
+
+We've fixed that.

--- a/scripts/update-action-to-use-docker-image-to-run-action
+++ b/scripts/update-action-to-use-docker-image-to-run-action
@@ -71,9 +71,9 @@ if 'REGISTRY' in os.environ:
     }
 
     registry = os.environ['REGISTRY']
-    if registry in registries
+    if registry in registries:
         registry = registries[registry]
-    else
+    else:
         print(ERROR + registry + " isn't a supported REGISTRY. Exiting." + ENDC)
         sys.exit(1)
 


### PR DESCRIPTION
It turns out our CI linting would show green for code that had failed linting. That is a bad setup. In the process, the last release had a syntax error in it.

This commit fixes that issue. The pylint problem still needs to be addressed.