### PR TITLE
Fix broken `make pylint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ push: build
 pylint: build $(PYTHON_COMMANDS)
 	$(foreach file, $(notdir $(PYTHON_COMMANDS)), \
 		echo "Linting $(file)"; \
-		docker run --entrypoint pylint --rm "ghcr.io/${IMAGE}:latest" /commands/$(file); \
+		docker run --entrypoint pylint --rm "ghcr.io/${IMAGE}:latest" /commands/$(file) || exit 1; \
 	)
 
 .PHONY: push


### PR DESCRIPTION
We now stop if any linting fails thereby failing the job if any fail. Previously the exit code for the job would be "0" if the last linting succeeded.

Fixes #65