### PR TITLE
Handle release already existing when uploading release notes

### DIFF
--- a/.release-notes/83.md
+++ b/.release-notes/83.md
@@ -1,0 +1,7 @@
+## Handle release already existing when uploading release notes
+
+Previously, the uploading of release notes assumed that the release didn't exist yet. If the release already existed, the release notes upload would fail.
+
+Only working when a release didn't exist made sense for all our ponylang usage. However, for other projects that create assets as part of the build process and store them in GitHub releases rather than Cloudsmith, the release might already exist.
+
+Now, we will check to see if the release exists. If it does, we update it with our release notes. If it doesn't, we will create the release like we previously did.

--- a/scripts/publish-release-notes-to-github
+++ b/scripts/publish-release-notes-to-github
@@ -65,5 +65,12 @@ g = Github(os.environ['RELEASE_TOKEN'])
 repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
 
 print(INFO + "Uploading release notes..." + ENDC)
-repo.create_git_release(version, version, release_notes)
+# check to see if the release already exists
+ghrelease = repo.get_release(version)
+if ghrelease:
+    print(INFO + "Release already exists. Updating release notes." + ENDC)
+    ghrelease.update_release(name=version, message=release_notes)
+else:
+    print(INFO + "Release does not exist. Creating release notes." + ENDC)
+    repo.create_git_release(version, version, release_notes)
 print(INFO + "Release notes uploaded." + ENDC)


### PR DESCRIPTION
Previously, the uploading of release notes assumed that the release didn't exist yet. This made sense for all our ponylang usage. However, for other projects that create assets as part of the build process and store them in GitHub releases rather than Cloudsmith, the release might already exist.

Now, we will check to see if the release exists. If it does, we update it with our release notes. If it doesn't, we will create the release like we previously did.