### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The v3 line of docker/login-action uses Node.js 20 which is deprecated by GitHub Actions. v4 upgrades to Node.js 24.

Also removed a stale version comment (`# v2.2.0`) that was inaccurate — the pinned SHA corresponded to a v3 release, not v2.2.0.