### PR TITLE
Fix release note publishing when no GitHub Release exists

### DIFF
--- a/.release-notes/fix-publish-when-no-release-exists.md
+++ b/.release-notes/fix-publish-when-no-release-exists.md
@@ -1,0 +1,3 @@
+## Fix release note publishing when no GitHub Release exists
+
+Release note publishing was broken for projects where the GitHub Release doesn't exist before the announcement stage. The `get_release` API call raises an exception on a missing release instead of returning a falsy value, so the fallback path that creates the release was never reached.

--- a/scripts/publish-release-notes-to-github
+++ b/scripts/publish-release-notes-to-github
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 from github import Github
+from github import UnknownObjectException
 
 ENDC = '\033[0m'
 ERROR = '\033[31m'
@@ -66,11 +67,11 @@ repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
 
 print(INFO + "Uploading release notes..." + ENDC)
 # check to see if the release already exists
-ghrelease = repo.get_release(version)
-if ghrelease:
+try:
+    ghrelease = repo.get_release(version)
     print(INFO + "Release already exists. Updating release notes." + ENDC)
     ghrelease.update_release(name=version, message=release_notes)
-else:
-    print(INFO + "Release does not exist. Creating release notes." + ENDC)
+except UnknownObjectException:
+    print(INFO + "Release does not exist. Creating release." + ENDC)
     repo.create_git_release(version, version, release_notes)
 print(INFO + "Release notes uploaded." + ENDC)


### PR DESCRIPTION
PR #83 changed `publish-release-notes-to-github` to check whether a GitHub Release already exists before creating one. The check uses `repo.get_release(version)`, which raises `UnknownObjectException` on a 404 rather than returning a falsy value. The `else` branch that calls `create_git_release` was never reachable.

This breaks all ponylang projects where the release is created by this script (no prior release exists). First failure: ponylang/hobby 0.6.0.

Wraps `get_release` in a try/except so the create path works again.