### PR TITLE
Add create-empty-github-release entrypoint; fix latest-release flag

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,22 @@
+## Add `create-empty-github-release` entrypoint
+
+There is a new `create-empty-github-release` entrypoint that creates an empty GitHub release for the tag being released. This lets release workflows attach build artefacts to the GitHub release as they are produced, rather than waiting until `publish-release-notes-to-github` runs to create the release.
+
+If a release already exists for the tag, `create-empty-github-release` leaves it alone, so the entrypoint is safe to run from a restarted release workflow.
+
+Example use:
+
+```yaml
+- name: Create empty GitHub release
+  uses: docker://ghcr.io/ponylang/release-bot-action:X.Y.Z
+  with:
+    entrypoint: create-empty-github-release
+  env:
+    RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+```
+
+## GitHub's `releases/latest` URL now points to the newest release
+
+`publish-release-notes-to-github` now enables GitHub's default "latest release" selection (by semantic version and creation date) when it publishes release notes. Previously, `https://github.com/OWNER/REPO/releases/latest` did not reliably point to the most recent release for repositories using this action.
+
+Re-running the announcement workflow against an older tag will not flip the `releases/latest` pointer away from a newer release — GitHub continues to pick the newest release by semver and date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- `releases/latest` URL on GitHub now points at the newest release ([PR #94](https://github.com/ponylang/release-bot-action/pull/94))
 
 ### Added
 
+- Add `create-empty-github-release` entrypoint ([PR #94](https://github.com/ponylang/release-bot-action/pull/94))
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 
 RUN pip3 install --break-system-packages\
   gitpython \
-  pygithub==1.55 \
+  pygithub==2.9.0 \
   pylint \
   pyyaml \
   zulip

--- a/README.md
+++ b/README.md
@@ -152,11 +152,15 @@ jobs:
 
 ### Release
 
-The meat of the release process. This is the workflow that builds our actual release artefacts, updates documentation and whatever else. Release-bot only provides two commands to be used in this workflow.
+The meat of the release process. This is the workflow that builds our actual release artefacts, updates documentation and whatever else. Release-bot provides three commands to be used in this workflow.
 
 - pre-artefact-changelog-check
 
 Can be used to verify that the release workflow wasn't "accidentally" triggered.
+
+- create-empty-github-release
+
+Creates an empty GitHub release for the version tag so that release artefacts can be attached to it as they are built. Not required unless you need a GitHub release for artefact attachment.
 
 - trigger-release-announcement
 
@@ -354,6 +358,30 @@ An example step config:
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
+```
+
+### create-empty-github-release
+
+Creates an empty GitHub release for the tag being released. The release is created with an empty body, not marked as a draft, and not marked as the latest release. The release body and the "latest" flag can be set later by `publish-release-notes-to-github`.
+
+This command exists so that release artefacts can be attached to the GitHub release as they are built during the `release` workflow. It should be run as part of the `pre-artefact-creation` job, after `pre-artefact-changelog-check`.
+
+If a release for the tag already exists, `create-empty-github-release` does nothing. This means the command is safe to re-run if the `release` workflow has to be restarted.
+
+- **Must** be triggered by an `X.Y.Z` tag push.
+- **Should** be run after `pre-artefact-changelog-check` and before any artefact building steps.
+
+`create-empty-github-release` requires a GitHub personal access token with `public_repo` access. The personal access token needs to be passed in the environment variable `RELEASE_TOKEN`.
+
+An example step config:
+
+```yml
+      - name: Create empty GitHub release
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        with:
+          entrypoint: create-empty-github-release
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
 
 ### delete-announcement-tag

--- a/scripts/add-announcement-to-last-week-in-pony
+++ b/scripts/add-announcement-to-last-week-in-pony
@@ -5,6 +5,7 @@
 import os
 import re
 import sys
+from github import Auth
 from github import Github
 
 ENDC = '\033[0m'
@@ -25,14 +26,14 @@ if 'GITHUB_REPOSITORY' not in os.environ:
     print(ERROR + "GITHUB_REPOSITORY needs to be set in env. Exiting." + ENDC)
     sys.exit(1)
 
-# version is in the form of "refs/tags/release-1.0.0" where the version is 1.0.0
+# version is in the form of "refs/tags/announce-1.0.0" where the version is 1.0.0
 version = re.sub('refs/tags/announce-', '', os.environ['GITHUB_REF'])
 
 release_repo = os.environ['GITHUB_REPOSITORY']
 
 print(INFO + "Adding release to Last Week in Pony..." + ENDC)
 
-g = Github(os.environ['RELEASE_TOKEN'])
+g = Github(auth=Auth.Token(os.environ['RELEASE_TOKEN']))
 repo = g.get_repo('ponylang/ponylang-website')
 results = repo.get_issues(labels=['last-week-in-pony'])
 if results.totalCount == 0:

--- a/scripts/create-empty-github-release
+++ b/scripts/create-empty-github-release
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
+
+import os
+import re
+import sys
+from github import Auth
+from github import Github
+from github import GithubException
+from github import UnknownObjectException
+
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
+NOTICE = '\033[33m'
+
+# validate env
+if 'RELEASE_TOKEN' not in os.environ:
+    print(ERROR + "RELEASE_TOKEN needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
+
+if 'GITHUB_REF' not in os.environ:
+    print(ERROR + "GITHUB_REF needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
+
+if 'GITHUB_REPOSITORY' not in os.environ:
+    print(ERROR + "GITHUB_REPOSITORY needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
+
+# version is in the form of "refs/tags/1.0.0" where the version is 1.0.0
+version = re.sub('refs/tags/', '', os.environ['GITHUB_REF'])
+
+g = Github(auth=Auth.Token(os.environ['RELEASE_TOKEN']))
+repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
+
+# If the release already exists, leave it alone. A prior run may have
+# uploaded assets, populated the body, or set the "latest" flag; modifying
+# any of that here would clobber recovery paths. Only create the release
+# when it's missing.
+print(INFO + "Checking for existing GitHub release for " + version + "..."
+      + ENDC)
+try:
+    repo.get_release(version)
+    print(INFO + "Release already exists. Not modifying." + ENDC)
+    sys.exit(0)
+except UnknownObjectException:
+    print(INFO + "Release does not exist. Creating empty release." + ENDC)
+except GithubException as e:
+    print(ERROR + f"GitHub API error: {e.status} {e.data}" + ENDC)
+    sys.exit(1)
+
+# Explicitly set make_latest="false" so the empty-body release is not
+# marked as the "latest" release. The "latest" flag is deferred until
+# publish-release-notes-to-github runs. PyGithub's create_git_release
+# defaults make_latest to "true", so the argument must be supplied.
+try:
+    repo.create_git_release(tag=version, name=version, message="",
+                            draft=False, prerelease=False,
+                            make_latest="false")
+    print(INFO + "Empty release created." + ENDC)
+except GithubException as e:
+    # A concurrent run may have created the release after the existence
+    # check above. The entrypoint is intended to be idempotent, so treat
+    # "already exists" as success.
+    errors = e.data.get('errors', []) if isinstance(e.data, dict) else []
+    already_exists = any(
+        isinstance(err, dict) and err.get('code') == 'already_exists'
+        for err in errors)
+    if e.status == 422 and already_exists:
+        print(INFO + "Release was created concurrently. Not modifying."
+              + ENDC)
+        sys.exit(0)
+    print(ERROR + f"GitHub API error: {e.status} {e.data}" + ENDC)
+    sys.exit(1)

--- a/scripts/publish-release-notes-to-github
+++ b/scripts/publish-release-notes-to-github
@@ -7,7 +7,9 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+from github import Auth
 from github import Github
+from github import GithubException
 from github import UnknownObjectException
 
 ENDC = '\033[0m'
@@ -28,7 +30,7 @@ if 'GITHUB_REPOSITORY' not in os.environ:
     print(ERROR + "GITHUB_REPOSITORY needs to be set in env. Exiting." + ENDC)
     sys.exit(1)
 
-# version is in the form of "refs/tags/release-1.0.0" where the version is 1.0.0
+# version is in the form of "refs/tags/announce-1.0.0" where the version is 1.0.0
 version = re.sub('refs/tags/announce-', '', os.environ['GITHUB_REF'])
 
 release_repo = os.environ['GITHUB_REPOSITORY']
@@ -62,16 +64,30 @@ else:
     print(INFO + "No CHANGELOG.md found." + ENDC)
 
 
-g = Github(os.environ['RELEASE_TOKEN'])
+g = Github(auth=Auth.Token(os.environ['RELEASE_TOKEN']))
 repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
 
 print(INFO + "Uploading release notes..." + ENDC)
 # check to see if the release already exists
+ghrelease = None
 try:
     ghrelease = repo.get_release(version)
-    print(INFO + "Release already exists. Updating release notes." + ENDC)
-    ghrelease.update_release(name=version, message=release_notes)
 except UnknownObjectException:
-    print(INFO + "Release does not exist. Creating release." + ENDC)
-    repo.create_git_release(version, version, release_notes)
+    pass
+except GithubException as e:
+    print(ERROR + f"GitHub API error: {e.status} {e.data}" + ENDC)
+    sys.exit(1)
+
+try:
+    if ghrelease is not None:
+        print(INFO + "Release already exists. Updating release notes." + ENDC)
+        ghrelease.update_release(name=version, message=release_notes,
+                                 make_latest="legacy")
+    else:
+        print(INFO + "Release does not exist. Creating release." + ENDC)
+        repo.create_git_release(version, version, release_notes,
+                                make_latest="legacy")
+except GithubException as e:
+    print(ERROR + f"GitHub API error: {e.status} {e.data}" + ENDC)
+    sys.exit(1)
 print(INFO + "Release notes uploaded." + ENDC)


### PR DESCRIPTION
Adds a new `create-empty-github-release` entrypoint that creates an empty GitHub release at the version tag so per-platform release jobs can attach binaries to it during artefact creation. Fixes `publish-release-notes-to-github` so GitHub's `releases/latest` URL points at the newest release — today it does not for any repo using this action.

Bumps PyGithub from 1.55 to 2.9.0 (the `make_latest` parameter was added in 2.1.0) and migrates the two PyGithub-using scripts off the positional `Github(token)` constructor (deprecated in 2.x) to `Github(auth=Auth.Token(...))`.

Design: ponylang/ponyup#406